### PR TITLE
fix(readme): resize arclix icon in readme file (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <br>
 <p align="center">
-    <img src="./public/images/arclix.svg">
+    <img src="./public/images/arclix.svg" width="500px">
      <br><br>
     <i>The <b>ARCLIX</b> is a command-line interface tool that you use to initialize and generate.
     <br> <b>React</b> applications directly from a command shell.</i>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Resized the Arclix icon to not occupy view space in `readme` file

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

-   [X] Bug fix
-   [ ] New Feature
-   [ ] Other

### Before submitting the PR, please make sure you do the following

-   [X] Read the [Contributing Guidelines](https://github.com/arclix/core/blob/master/CONTRIBUTING.md).
-   [X] Read the [Pull Request Guidelines](https://github.com/arclix/core/blob/master/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/arclix/core/blob/master/.github/COMMIT_CONVENTION.md).
-   [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
-   [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
-   [X] Ideally, include relevant tests that fail without this PR but pass with it.
