### PR TITLE
perf(generate): increase performance by reducing unnecessary reads (#57)

### DIFF
--- a/src/helpers/checkProperty.test.ts
+++ b/src/helpers/checkProperty.test.ts
@@ -1,28 +1,28 @@
 import { describe, expect, it } from "vitest";
+import { packageType } from "../types/interface";
 import checkProperty from "./checkProperty";
 
 describe("Check Property", () => {
-    const normalPath = "./package.json";
-    const wrongPath = "./mocks/mockPackage.json";
-    const mockPath = "./src/mocks/mock.package.json";
+    const mockPkg: packageType = {
+        dependencies: {},
+        devDependencies: {
+            typescript: "^4.9.4",
+            sass: "^1.58.3",
+        },
+    };
 
     it("should return true if it's a typescript project", async () => {
-        const isTypeScript = await checkProperty("typescript", mockPath);
+        const isTypeScript = await checkProperty("typescript", mockPkg);
         expect(isTypeScript).toBe(true);
     });
 
     it("should return true if it's a scss project", async () => {
-        const isScss = await checkProperty("sass", mockPath);
+        const isScss = await checkProperty("sass", mockPkg);
         expect(isScss).toBe(true);
     });
 
     it("should return false if it's not property project", async () => {
-        const isScss = await checkProperty("sass", normalPath);
+        const isScss = await checkProperty("something", mockPkg);
         expect(isScss).toBe(false);
-    });
-
-    it("should return false if the package doesn't exist in the project", async () => {
-        const isTypeScript = await checkProperty("typescript", wrongPath);
-        expect(isTypeScript).toBe(false);
     });
 });

--- a/src/helpers/checkProperty.ts
+++ b/src/helpers/checkProperty.ts
@@ -1,37 +1,24 @@
-import fs from "fs";
-import path from "path";
-import getRootPath from "./getRootPath.js";
+import { packageType } from "../types/interface.js";
 
 /**
  * Checks whether the given property exists or not
  *
  * @param property property to check
- * @param packagePath path to package.json
+ * @param pkg package.json contents
  * @returns true if exists or false
  */
 const checkProperty = async (
     property: string,
-    packagePath: string,
+    pkg: packageType,
 ): Promise<boolean> => {
-    const rootPath = getRootPath(process.cwd());
-    const packageJsonPath = path.resolve(rootPath, packagePath);
-
-    try {
-        const data = await fs.promises.readFile(packageJsonPath, "utf-8");
-        const packageJson = JSON.parse(data);
-        const dependencies = packageJson.dependencies || {};
-        const devDependencies = packageJson.devDependencies || {};
-
-        if (
-            Object.hasOwn(dependencies, property) ||
-            Object.hasOwn(devDependencies, property)
-        ) {
-            return true;
-        }
-        return false;
-    } catch (error) {
-        return false;
+    const { dependencies, devDependencies } = pkg;
+    if (
+        Object.hasOwn(dependencies, property) ||
+        Object.hasOwn(devDependencies, property)
+    ) {
+        return true;
     }
+    return false;
 };
 
 export default checkProperty;

--- a/src/helpers/checkReact.test.ts
+++ b/src/helpers/checkReact.test.ts
@@ -1,23 +1,30 @@
 import { describe, expect, it } from "vitest";
+import { packageType } from "../types/interface";
 import checkReact from "./checkReact";
 
 describe("Check React", () => {
-    const normalPath = "./package.json";
-    const wrongPath = "./mocks/mockPackage.json";
-    const mockPath = "./src/mocks/mock.package.json";
+    const wrongPkg: packageType = {
+        dependencies: {},
+        devDependencies: {},
+    };
+    const mockPkg: packageType = {
+        dependencies: {
+            react: "^18.2.0",
+            "react-dom": "^18.2.0",
+        },
+        devDependencies: {
+            react: "^18.2.0",
+            "react-dom": "^18.2.0",
+        },
+    };
 
     it("should return true if it's a react project", async () => {
-        const isReact = await checkReact(mockPath);
+        const isReact = await checkReact(mockPkg);
         expect(isReact).toBe(true);
     });
 
     it("should return false if it's not a react project", async () => {
-        const isReact = await checkReact(normalPath);
-        expect(isReact).toBe(false);
-    });
-
-    it("should return false if the package doesn't exist in the project", async () => {
-        const isReact = await checkReact(wrongPath);
+        const isReact = await checkReact(wrongPkg);
         expect(isReact).toBe(false);
     });
 });

--- a/src/helpers/checkReact.ts
+++ b/src/helpers/checkReact.ts
@@ -1,37 +1,24 @@
-import fs from "fs";
-import path from "path";
-import getRootPath from "./getRootPath.js";
+import { packageType } from "../types/interface.js";
 
 /**
  * Check wether the project is a React project or not
  *
- * @param packagePath path to package.json
+ * @param pkg package.json contents
  * @returns true it it's a react project or flase
  */
-const checkReact = async (packagePath: string): Promise<boolean> => {
-    const rootPath = getRootPath(process.cwd());
-    const packageJsonPath = path.resolve(rootPath, packagePath);
+const checkReact = async (pkg: packageType): Promise<boolean> => {
+    const { dependencies, devDependencies } = pkg;
+    const dependenciesCheck: boolean =
+        Object.hasOwn(dependencies, "react") &&
+        Object.hasOwn(dependencies, "react-dom");
+    const devDependenciesCheck: boolean =
+        Object.hasOwn(devDependencies, "react") &&
+        Object.hasOwn(devDependencies, "react-dom");
 
-    try {
-        const data = await fs.promises.readFile(packageJsonPath, "utf-8");
-        const packageJson = JSON.parse(data);
-        const dependencies = packageJson.dependencies || {};
-        const devDependencies = packageJson.devDependencies || {};
-
-        const dependenciesCheck: boolean =
-            Object.hasOwn(dependencies, "react") &&
-            Object.hasOwn(dependencies, "react-dom");
-        const devDependenciesCheck: boolean =
-            Object.hasOwn(devDependencies, "react") &&
-            Object.hasOwn(devDependencies, "react-dom");
-
-        if (dependenciesCheck || devDependenciesCheck) {
-            return true;
-        }
-        return false;
-    } catch (error) {
-        return false;
+    if (dependenciesCheck || devDependenciesCheck) {
+        return true;
     }
+    return false;
 };
 
 export default checkReact;

--- a/src/helpers/getPackageFile.test.ts
+++ b/src/helpers/getPackageFile.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import getPackageFile from "./getPackageFile";
+
+describe("Get package.json file", () => {
+    it("should return package.json file content if exists", async () => {
+        const pkg = await getPackageFile("./src/mocks/mock.package.json");
+        expect(pkg).toBeTypeOf("object");
+    });
+
+    it("should return null if package.json file doesn't exists", async () => {
+        const pkg = await getPackageFile("./mocks/mock.package.json");
+        expect(pkg).toBe(null);
+    });
+});

--- a/src/helpers/getPackageFile.ts
+++ b/src/helpers/getPackageFile.ts
@@ -1,0 +1,30 @@
+import fs from "fs";
+import path from "path";
+import { packageType } from "../types/interface.js";
+import getRootPath from "./getRootPath.js";
+
+/**
+ * Get the dependencies and deveDepencies from package
+ *
+ * @param packagePath of the package.json file
+ * @returns dependencies and deveDependencies from package.json or null
+ */
+const getPackageFile = async (
+    packagePath: string,
+): Promise<packageType | null> => {
+    const rootPath = getRootPath(process.cwd());
+    const packageJsonPath = path.resolve(rootPath, packagePath);
+
+    if (fs.existsSync(packageJsonPath)) {
+        const data = await fs.promises.readFile(packageJsonPath, "utf-8");
+        const packageJson = JSON.parse(data);
+        const dependencies = packageJson.dependencies || {};
+        const devDependencies = packageJson.devDependencies || {};
+
+        return { dependencies, devDependencies };
+    }
+
+    return null;
+};
+
+export default getPackageFile;

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,5 +1,7 @@
 import checkReact from "./checkReact.js";
+import getConfig from "./getConfig.js";
 import getRootPath from "./getRootPath.js";
+import getPackageFile from "./getPackageFile.js";
 import checkProperty from "./checkProperty.js";
 
-export { checkReact, checkProperty, getRootPath };
+export { checkReact, checkProperty, getConfig, getRootPath, getPackageFile };

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -19,4 +19,6 @@ interface ArclixConfig {
     generate: GenerateConfig;
 }
 
-export { ContentArgs, ArclixConfig, GenerateConfig };
+type packageType = { dependencies: any; devDependencies: any };
+
+export { ContentArgs, ArclixConfig, GenerateConfig, packageType };


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- removed unnecessary file reads on `package.json`
- added method `getPackgeFile` to read `package.json` once and return it's content
- updated `checkReact` and `checkProperty` to use the content retrieved from `getPackageFile`
- updated the tests for `checkReact` and `checkProperty`
- added  test for `getPackageFile`.

### Additional context

Before these changes it took an average of `2.23ms  - 2.7ms` to generate basic component, after these changes reduced the time to an average of `1.2ms - 1.7ms`.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

-   [ ] Bug fix
-   [ ] New Feature
-   [X] Other

### Before submitting the PR, please make sure you do the following

-   [X] Read the [Contributing Guidelines](https://github.com/arclix/core/blob/master/CONTRIBUTING.md).
-   [X] Read the [Pull Request Guidelines](https://github.com/arclix/core/blob/master/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/arclix/core/blob/master/.github/COMMIT_CONVENTION.md).
-   [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
-   [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
-   [X] Ideally, include relevant tests that fail without this PR but pass with it.
