### PR TITLE
fix:  index file for flat option (#71)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "arclix",
-    "version": "0.0.10",
+    "version": "0.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "arclix",
-            "version": "0.0.10",
+            "version": "0.1.1",
             "license": "ISC",
             "dependencies": {
                 "chalk": "^5.2.0",

--- a/src/generate/GenerateComponent.ts
+++ b/src/generate/GenerateComponent.ts
@@ -147,6 +147,7 @@ export default class GenerateComponent {
                         options.scopeStyle || this.config?.generate.scopeStyle,
                     addIndex:
                         options.addIndex || this.config?.generate.addIndex,
+                    flat: options.flat
                 },
                 this.fileCreationError,
             );

--- a/src/generate/GenerateComponent.ts
+++ b/src/generate/GenerateComponent.ts
@@ -147,7 +147,7 @@ export default class GenerateComponent {
                         options.scopeStyle || this.config?.generate.scopeStyle,
                     addIndex:
                         options.addIndex || this.config?.generate.addIndex,
-                    flat: options.flat
+                    flat: options.flat,
                 },
                 this.fileCreationError,
             );

--- a/src/generate/GenerateComponentUtility.ts
+++ b/src/generate/GenerateComponentUtility.ts
@@ -67,13 +67,14 @@ export class GenerateComponentUtility {
         this.writeToFile(this.argParams.folderPath, fileName, content);
     };
     private createIndexFile = () => {
-        let content = '';
-        if(this.argParams.flat){
+        let content = "";
+        if (this.argParams.flat) {
             content = `export * from './${this.argParams.componentName}'`;
-        }
-        else{
-            const splitedPath = this.argParams.folderPath.split('/');
-            content = `export * from '../${splitedPath[splitedPath.length-2]}'`;
+        } else {
+            const splitedPath = this.argParams.folderPath.split("/");
+            content = `export * from '../${
+                splitedPath[splitedPath.length - 2]
+            }'`;
         }
         const fileName = `index${this.argParams.type ? ".ts" : ".js"}`;
         this.writeToFile(this.argParams.folderPath, fileName, content);

--- a/src/generate/GenerateComponentUtility.ts
+++ b/src/generate/GenerateComponentUtility.ts
@@ -67,7 +67,14 @@ export class GenerateComponentUtility {
         this.writeToFile(this.argParams.folderPath, fileName, content);
     };
     private createIndexFile = () => {
-        const content = `export * from './${this.argParams.componentName}'`;
+        let content = '';
+        if(this.argParams.flat){
+            content = `export * from './${this.argParams.componentName}'`;
+        }
+        else{
+            const splitedPath = this.argParams.folderPath.split('/');
+            content = `export * from '../${splitedPath[splitedPath.length-2]}'`;
+        }
         const fileName = `index${this.argParams.type ? ".ts" : ".js"}`;
         this.writeToFile(this.argParams.folderPath, fileName, content);
     };

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -5,6 +5,7 @@ export interface ContentArgs {
     type: boolean;
     scopeStyle: boolean;
     addIndex: boolean;
+    flat: boolean;
 }
 
 export interface GenerateConfig {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
The issue is that when we attempted to create a component using the flat and addIndex options, they expected the component to be exported in an index file, but instead, it was exported in a folder with the component name, which should not have been created as they used the flat option.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

-   [X] Bug fix
-   [ ] New Feature
-   [ ] Other

### Before submitting the PR, please make sure you do the following

-   [X] Read the [Contributing Guidelines](https://github.com/arclix/core/blob/master/CONTRIBUTING.md).
-   [X] Read the [Pull Request Guidelines](https://github.com/arclix/core/blob/master/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/arclix/core/blob/master/.github/COMMIT_CONVENTION.md).
-   [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
-   [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
-   [X] Ideally, include relevant tests that fail without this PR but pass with it.
