### PR TITLE
feat(generate)!: add typescript as default template (#83)

### DIFF
--- a/src/create/GenerateConfigFile.ts
+++ b/src/create/GenerateConfigFile.ts
@@ -22,6 +22,7 @@ export default class GenerateConfigFile {
             addIndex: false,
             skipTest: false,
             scopeStyle: false,
+            template: "tsx",
             defaultPath: "./",
         };
 

--- a/src/generate/GenerateComponentUtility.ts
+++ b/src/generate/GenerateComponentUtility.ts
@@ -12,13 +12,13 @@ import { componentTemplate, testTemplate } from "./templates/index.js";
  */
 export class GenerateComponentUtility {
     private readonly styleType: ".scss" | ".css";
-    private readonly componentType: ".tsx" | ".jsx";
+    private readonly indexType: ".ts" | ".js";
     constructor(
         private readonly contentArgs: ContentArgs,
         public fileCreationError: boolean,
     ) {
         this.styleType = this.contentArgs.style ? ".scss" : ".css";
-        this.componentType = this.contentArgs.type ? ".tsx" : ".jsx";
+        this.indexType = this.contentArgs.template === "tsx" ? ".ts" : ".js";
     }
     private writeToFile = (
         folderPath: string,
@@ -40,7 +40,7 @@ export class GenerateComponentUtility {
             scopeStyle: this.contentArgs.scopeStyle,
             styleType: this.styleType,
         });
-        const fileName = `${this.contentArgs.componentName}${this.componentType}`;
+        const fileName = `${this.contentArgs.componentName}.${this.contentArgs.template}`;
         this.writeToFile(this.contentArgs.folderPath, fileName, content);
     };
     private createStyleFile = () => {
@@ -50,7 +50,7 @@ export class GenerateComponentUtility {
         this.writeToFile(this.contentArgs.folderPath, fileName, "");
     };
     private createTestFile = () => {
-        const fileName = `${this.contentArgs.componentName}.test${this.componentType}`;
+        const fileName = `${this.contentArgs.componentName}.test.${this.contentArgs.template}`;
         const content = testTemplate(
             this.contentArgs.componentName,
             this.contentArgs.addIndex,
@@ -58,12 +58,12 @@ export class GenerateComponentUtility {
         this.writeToFile(this.contentArgs.folderPath, fileName, content);
     };
     private createIndexFile = () => {
-        const { flat, type, folderPath, componentName } = this.contentArgs;
+        const { flat, folderPath, componentName } = this.contentArgs;
         const filePath = flat
             ? `"../${folderPath.split("/").slice(-2, -1)[0]}"`
             : `"./${componentName}"`;
         const content = `export * from ${filePath}`;
-        const fileName = `index${type ? ".ts" : ".js"}`;
+        const fileName = `index${this.indexType}`;
         this.writeToFile(folderPath, fileName, content);
     };
 

--- a/src/generate/templates/component.ts
+++ b/src/generate/templates/component.ts
@@ -1,7 +1,7 @@
 import type { ContentArgs } from "../../types/type.js";
 
 interface ComponentArgs
-    extends Omit<ContentArgs, "folderPath" | "style" | "type" | "flat"> {
+    extends Pick<ContentArgs, "addIndex" | "scopeStyle" | "componentName"> {
     styleType: string;
 }
 

--- a/src/tests/checkProperty.test.ts
+++ b/src/tests/checkProperty.test.ts
@@ -6,15 +6,9 @@ describe("Check Property", () => {
     const mockPkg: PackageType = {
         dependencies: {},
         devDependencies: {
-            typescript: "^4.9.4",
             sass: "^1.58.3",
         },
     } as const;
-
-    it("should return true if it's a typescript project", async () => {
-        const isTypeScript = await checkProperty("typescript", mockPkg);
-        expect(isTypeScript).toBe(true);
-    });
 
     it("should return true if it's a scss project", async () => {
         const isScss = await checkProperty("sass", mockPkg);

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -1,8 +1,10 @@
+export type Template = "jsx" | "tsx";
+
 export interface ContentArgs {
     componentName: string;
+    template: Template;
     folderPath: string;
     style?: boolean;
-    type: boolean;
     scopeStyle: boolean;
     addIndex: boolean;
     flat: boolean;
@@ -13,6 +15,7 @@ export interface GenerateConfig {
     addIndex: boolean;
     skipTest: boolean;
     scopeStyle: boolean;
+    template: Template;
     defaultPath: string;
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
 
- Added `TypeScript` as default template for component generation.
- Added `template` property to config.
- Removed template checking using `package.json`.

### Additional context

Now if the developer needs `JavaScript` as the template for their project they can customize the `template` property in `arclix.config.json` file.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

-   [ ] Bug fix
-   [X] New Feature
-   [ ] Other

### Before submitting the PR, please make sure you do the following

-   [X] Read the [Contributing Guidelines](https://github.com/arclix/core/blob/master/CONTRIBUTING.md).
-   [X] Read the [Pull Request Guidelines](https://github.com/arclix/core/blob/master/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/arclix/core/blob/master/.github/COMMIT_CONVENTION.md).
-   [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
-   [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
-   [X] Ideally, include relevant tests that fail without this PR but pass with it.
