### PR TITLE
feat(generate)!: add dynamic component type support in config (#95)

### DIFF
--- a/src/generate/GenerateComponent.ts
+++ b/src/generate/GenerateComponent.ts
@@ -128,11 +128,21 @@ export default class GenerateComponent {
       return;
     }
 
+    const type = options.type ?? 'default';
+    // Throw error if the given type doesn't exist in the config.
+    if (this.config && !this.config.component[type]) {
+      spinner.error({
+        text: chalk.red(
+          `Component type ${type} doesn't exist in the config file.\n`,
+        ),
+      });
+      return;
+    }
+
     spinner.start({ text: 'Creating component...' });
     // Generate multiple and nested components.
     try {
       componentNames.forEach((componentName, index) => {
-        const type = options.type ?? 'default';
         const path = this.getFolderPath(componentName, options);
         const cliOptions: CLIOptions = {
           addIndex: this.getOptions(options, 'addIndex'),

--- a/src/generate/GenerateComponentUtility.ts
+++ b/src/generate/GenerateComponentUtility.ts
@@ -19,9 +19,11 @@ export class GenerateComponentUtility {
 
   constructor(private readonly contentArgs: ContentArgs) {
     this.styleType = `.${this.contentArgs.cssPreprocessor}`;
-    this.indexType = this.contentArgs.usesTypeScript ? '.ts' : '.js';
-    this.template = this.contentArgs.usesTypeScript ? 'tsx' : 'jsx';
+    [this.indexType, this.template] = this.contentArgs.usesTypeScript
+      ? ['.ts', 'tsx']
+      : ['.js', 'jsx'];
   }
+
   private writeToFile = (
     folderPath: string,
     fileName: string,
@@ -33,17 +35,22 @@ export class GenerateComponentUtility {
       }
     });
   };
+
   private createComponent = () => {
-    const { addIndex, scopeStyle, path } = this.contentArgs.options;
+    const {
+      componentName,
+      options: { addIndex, scopeStyle, path },
+    } = this.contentArgs;
     const content = componentTemplate({
       addIndex,
-      componentName: this.contentArgs.componentName,
+      componentName,
       scopeStyle,
       styleType: this.styleType,
     });
-    const fileName = `${this.contentArgs.componentName}.${this.template}`;
+    const fileName = `${componentName}.${this.template}`;
     this.writeToFile(path, fileName, content);
   };
+
   private createStyleFile = () => {
     const { scopeStyle, path } = this.contentArgs.options;
     const fileName = `${this.contentArgs.componentName}${
@@ -51,12 +58,14 @@ export class GenerateComponentUtility {
     }${this.styleType}`;
     this.writeToFile(path, fileName, '');
   };
+
   private createTestFile = () => {
     const { addIndex, path } = this.contentArgs.options;
     const fileName = `${this.contentArgs.componentName}.test.${this.template}`;
     const content = testTemplate(this.contentArgs.componentName, addIndex);
     this.writeToFile(path, fileName, content);
   };
+
   private createIndexFile = () => {
     const { path: folderPath, flat } = this.contentArgs.options;
     const filePath = flat
@@ -66,6 +75,7 @@ export class GenerateComponentUtility {
     const fileName = `index${this.indexType}`;
     this.writeToFile(folderPath, fileName, content);
   };
+
   private createStoryFile = () => {
     const {
       componentName,

--- a/src/generate/GenerateConfigFile.ts
+++ b/src/generate/GenerateConfigFile.ts
@@ -33,7 +33,7 @@ export default class GenerateConfigFile {
   }
 
   /**
-   * Generates config file while creating the project if projectName exists.
+   * Generates config file while creating the project if `projectName` exists.
    * Otherwise generates config file to the existing project.
    *
    * @param projectName to be created with arclix

--- a/src/generate/helpers/checkReact.ts
+++ b/src/generate/helpers/checkReact.ts
@@ -4,7 +4,7 @@ import type { PackageType } from '../../types/type.js';
  * Check wether the project is a `React` project or not.
  *
  * @param pkg properties of package.json file.
- * @returns `true` it it's a react project or `flase`.
+ * @returns `true` if it's a react project or `false`.
  */
 const checkReact = async (pkg: PackageType): Promise<boolean> => {
   const { dependencies, devDependencies } = pkg;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import type { CLIOptions } from './types/type.js';
 import { Command, AliasCommand } from './types/type.js';
 import { log, emptyLine, primaryChalk, spinner } from './utilities/utility.js';
 
-const version = 'ARCLIX v0.1.3';
+const version = 'ARCLIX v0.1.4';
 const createProjectInstance = new CreateProject();
 const generateComponentInstance = new GenerateComponent();
 const generateConfigFileInstance = new GenerateConfigFile();
@@ -35,7 +35,7 @@ program
     log('\n' + primaryChalk.italic.bold(version));
     emptyLine();
 
-    // Throw error if the projectname is not in lowercase
+    // Throw error if the project name is not in lowercase
     if (!checkProjectName(projectName)) {
       spinner.error({
         text: chalk.red('Project name should be in lowercase\n'),
@@ -62,20 +62,21 @@ generate
   .option('--addStory', 'Adds storybook story to the component.')
   .option('-f, --flat', 'Generates components without parent folder.')
   .option('-p, --path <string>', 'Generates components based on the path.')
+  .option(
+    '--type <string>',
+    'Specify the component type based on config to be generated.',
+  )
   .action(async (...actions) => {
-    const start = performance.now();
     log('\n' + primaryChalk.italic.bold(version));
     emptyLine();
     const componentNames: string[] = actions[2].args;
     const options: CLIOptions = actions[2]._optionValues;
     await generateComponentInstance.generateComponent(componentNames, options);
-    const end = performance.now();
-    console.log(`Time taken to generate is ${end - start}ms.`);
   });
 
 program
   .command(Command.INIT)
-  .description('Generated config file to the existing react project.')
+  .description('Generates config file to the existing react project.')
   .action(() => {
     log('\n' + primaryChalk.italic.bold(version));
     generateConfigFileInstance.generateConfigFile();

--- a/src/tests/generateComponent.test.ts
+++ b/src/tests/generateComponent.test.ts
@@ -33,6 +33,42 @@ describe('Generate Component', () => {
     expect(spinnerError).toHaveBeenCalled();
   });
 
+  it("should throw error if it's not a react project", async () => {
+    const spinnerError = vi.spyOn(spinner, 'error');
+    await generateComponentInstance.generateComponent(
+      ['Sample'],
+      {
+        flat: true,
+        addIndex: false,
+        addStory: false,
+        addTest: true,
+        path: './src/mocks',
+        scopeStyle: false,
+        type: 'default',
+      },
+      'package.json',
+    );
+    expect(spinnerError).toHaveBeenCalled();
+  });
+
+  it('should throw error if the given path is invalid', async () => {
+    const spinnerError = vi.spyOn(spinner, 'error');
+    await generateComponentInstance.generateComponent(
+      ['Sample'],
+      {
+        flat: true,
+        addIndex: false,
+        addStory: false,
+        addTest: true,
+        path: './src/mock',
+        scopeStyle: false,
+        type: 'default',
+      },
+      packagePath,
+    );
+    expect(spinnerError).toHaveBeenCalled();
+  });
+
   it("should generate component without folder with name 'Sample'", async () => {
     await generateComponentInstance.generateComponent(
       ['Sample'],
@@ -251,6 +287,24 @@ describe('Generate Component', () => {
       expect(nestedStyleFileExists).toBe(true);
       expect(nestedTestFileExists).toBe(true);
     }, 5000);
+  }, 10000);
+
+  it('should throw error while generating nested components with --flat option', async () => {
+    const spinnerError = vi.spyOn(spinner, 'error');
+    await generateComponentInstance.generateComponent(
+      ['Sample4/Nested'],
+      {
+        flat: true,
+        addIndex: false,
+        addStory: false,
+        addTest: true,
+        scopeStyle: false,
+        path: './src/mocks',
+        type: 'default',
+      },
+      packagePath,
+    );
+    expect(spinnerError).toHaveBeenCalled();
   }, 10000);
 
   afterAll(async () => {

--- a/src/tests/getRootDirectory.test.ts
+++ b/src/tests/getRootDirectory.test.ts
@@ -7,7 +7,7 @@ describe('Get Root Directory', () => {
     expect(getRootDirectory(path.sep)).toBeNull();
   });
 
-  it("should return root path if it has 'src'", () => {
-    expect(getRootDirectory()).not.toBeNull();
+  it('should return root path', () => {
+    expect(getRootDirectory(process.cwd())).not.toBeNull();
   });
 });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Added support for dynamic component type in config for generation.

### Additional context

Now the developers can create their own component `type` in the `config` file for their project which has it's own configuration.
If the user want to generate certain files every time with certain configuration and not the common configuration in config file they can now create their own type for the component and add the `type` along with it's configuration in the config file.

For example the user wants certain file like `pages` to have different configuration than the `default` one then he could add any name for the type in the config file like:

```json
{
  "component": {
    "default": {
      "cssPreprocessor": "css",
      "usesTypeScript": true,
      "scopeStyle": true,
      "addStory": true,
      "addIndex": true,
      "addTest": true,
      "flat": false,
      "path": "./"
    },
    "pages": {
      "cssPreprocessor": "pcss",
      "path": "src/pages"
    }
  }
}

```

For this example I took the name name as `pages` user can name anything they want. So to use this `pages` configuration while generating the component, run the generate command with `type` flag like:

```bash
npx arclix@latest g c UserPage --type=pages
```

Here, `type` flag accepts only the valid types provided in the config file.
Now the `UserPage` component would be generated with the configuration provided in `pages` type in config file.


>**Note**: If the `type` flag is not provided then `default` configuration will be used for component generation.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/arclix/core/blob/master/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/arclix/core/blob/master/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/arclix/core/blob/master/.github/COMMIT_CONVENTION.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
