### PR TITLE
feat(core)!: introduce customTemplate support in arclix config (#96)

### DIFF
--- a/src/generate/GenerateComponentUtility.ts
+++ b/src/generate/GenerateComponentUtility.ts
@@ -1,11 +1,17 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import type { ContentArgs, Template } from '../types/type.js';
+import { CustomTemplate } from '../types/type.js';
+import type {
+  ContentArgs,
+  CustomTemplateType,
+  Template,
+} from '../types/type.js';
 import {
   componentTemplate,
   testTemplate,
   storyTemplate,
 } from './templates/index.js';
+import { logError } from '../utilities/utility.js';
 
 /**
  * A utility class to generate component based on arguments.
@@ -16,12 +22,35 @@ export class GenerateComponentUtility {
   private readonly template: Template;
   private readonly styleType: string;
   private readonly indexType: '.ts' | '.js';
+  private readonly customTemplate: CustomTemplateType | null;
 
   constructor(private readonly contentArgs: ContentArgs) {
     this.styleType = `.${this.contentArgs.cssPreprocessor}`;
     [this.indexType, this.template] = this.contentArgs.usesTypeScript
       ? ['.ts', 'tsx']
       : ['.js', 'jsx'];
+    this.customTemplate = this.contentArgs.customTemplate ?? null;
+  }
+
+  private async getCustomTemplateContent(
+    template: CustomTemplate,
+    componentName: string,
+  ) {
+    const filePath = this.customTemplate?.[template];
+
+    if (!filePath) {
+      return null;
+    }
+
+    try {
+      const content = await fs.promises.readFile(filePath, 'utf-8');
+      return content.replace(/TemplateComponent/g, componentName);
+    } catch (error) {
+      logError(
+        `No file exists or error reading file in the given path for ${template} in customTemplate`,
+      );
+      process.exit(1);
+    }
   }
 
   private writeToFile = (
@@ -31,38 +60,59 @@ export class GenerateComponentUtility {
   ) => {
     fs.writeFile(path.join(folderPath, fileName), content, (err) => {
       if (err) {
-        throw err;
+        logError(err.message);
+        process.exit(1);
       }
     });
   };
 
-  private createComponent = () => {
+  private createComponent = async () => {
     const {
       componentName,
       options: { addIndex, scopeStyle, path },
     } = this.contentArgs;
-    const content = componentTemplate({
-      addIndex,
-      componentName,
-      scopeStyle,
-      styleType: this.styleType,
-    });
+    const content =
+      (await this.getCustomTemplateContent(
+        CustomTemplate.COMPONENT,
+        componentName,
+      )) ??
+      componentTemplate({
+        addIndex,
+        componentName,
+        scopeStyle,
+        styleType: this.styleType,
+      });
     const fileName = `${componentName}.${this.template}`;
     this.writeToFile(path, fileName, content);
   };
 
-  private createStyleFile = () => {
-    const { scopeStyle, path } = this.contentArgs.options;
-    const fileName = `${this.contentArgs.componentName}${
-      scopeStyle ? '.module' : ''
-    }${this.styleType}`;
-    this.writeToFile(path, fileName, '');
+  private createStyleFile = async () => {
+    const {
+      componentName,
+      options: { scopeStyle, path },
+    } = this.contentArgs;
+    const fileName = `${componentName}${scopeStyle ? '.module' : ''}${
+      this.styleType
+    }`;
+    const content =
+      (await this.getCustomTemplateContent(
+        CustomTemplate.STYLE,
+        componentName,
+      )) ?? '';
+    this.writeToFile(path, fileName, content);
   };
 
-  private createTestFile = () => {
-    const { addIndex, path } = this.contentArgs.options;
-    const fileName = `${this.contentArgs.componentName}.test.${this.template}`;
-    const content = testTemplate(this.contentArgs.componentName, addIndex);
+  private createTestFile = async () => {
+    const {
+      componentName,
+      options: { addIndex, path },
+    } = this.contentArgs;
+    const fileName = `${componentName}.test.${this.template}`;
+    const content =
+      (await this.getCustomTemplateContent(
+        CustomTemplate.TEST,
+        componentName,
+      )) ?? testTemplate(this.contentArgs.componentName, addIndex);
     this.writeToFile(path, fileName, content);
   };
 
@@ -76,13 +126,17 @@ export class GenerateComponentUtility {
     this.writeToFile(folderPath, fileName, content);
   };
 
-  private createStoryFile = () => {
+  private createStoryFile = async () => {
     const {
       componentName,
       options: { addIndex, path },
     } = this.contentArgs;
     const fileName = `${componentName}.stories.${this.template}`;
-    const content = storyTemplate(componentName, addIndex);
+    const content =
+      (await this.getCustomTemplateContent(
+        CustomTemplate.STORY,
+        componentName,
+      )) ?? storyTemplate(componentName, addIndex);
     this.writeToFile(path, fileName, content);
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 import chalk from 'chalk';
 import pacote from 'pacote';
 import path, { dirname } from 'node:path';
-import { program } from 'commander';
+import { program as cli } from 'commander';
 import GenerateComponent from './generate/GenerateComponent.js';
 import GenerateConfigFile from './generate/GenerateConfigFile.js';
 import type { CLIOptions } from './types/type.js';
@@ -55,13 +55,9 @@ ${primaryChalk(`npm i -D arclix@${latestVersion}`)}
 
 await notifyUpdate();
 
-program.version(
-  version,
-  '-v --version',
-  'Displays the version of Arclix in use',
-);
+cli.version(version, '-v --version', 'Displays the version of Arclix in use');
 
-const generate = program
+const generate = cli
   .command(Command.GENERATE)
   .alias(AliasCommand.GENERATE)
   .description('Generates based on argument in the current directory.');
@@ -89,7 +85,7 @@ generate
     await generateComponentInstance.generateComponent(componentNames, options);
   });
 
-program
+cli
   .command(Command.INIT)
   .description('Generates config file to the existing react project.')
   .action(() => {
@@ -97,4 +93,4 @@ program
     generateConfigFileInstance.generateConfigFile();
   });
 
-program.parse(process.argv);
+cli.parse(process.argv);

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -15,6 +15,10 @@ export type BooleanProps<T> = {
   [K in keyof T as T[K] extends boolean ? K : never]: boolean;
 };
 
+export type CustomTemplateType = Partial<{
+  [K in CustomTemplate]: string;
+}>;
+
 export interface CLIOptions {
   addIndex: boolean;
   addStory: boolean;
@@ -28,12 +32,14 @@ export interface CLIOptions {
 export interface ComponentConfig extends Omit<CLIOptions, 'type'> {
   cssPreprocessor: string;
   usesTypeScript: boolean;
+  customTemplate?: CustomTemplateType;
 }
 
 export interface ContentArgs {
   componentName: string;
   cssPreprocessor: string;
   usesTypeScript: boolean;
+  customTemplate?: CustomTemplateType;
   options: CLIOptions;
 }
 
@@ -58,4 +64,11 @@ export enum Command {
 export enum AliasCommand {
   GENERATE = 'g',
   COMPONENT = 'c',
+}
+
+export enum CustomTemplate {
+  COMPONENT = 'component',
+  STYLE = 'style',
+  TEST = 'test',
+  STORY = 'story',
 }

--- a/src/utilities/utility.ts
+++ b/src/utilities/utility.ts
@@ -4,6 +4,7 @@ import { createSpinner } from 'nanospinner';
 
 const log = console.log;
 const spinner = createSpinner();
+const logError = (error: string) => spinner.error({ text: chalk.red(error) });
 const emptyLine = () => log();
 const primaryChalk = chalk.hex('#09d3ac');
 
@@ -16,4 +17,12 @@ const getPkg = async (pkgPath: string) => {
   return JSON.parse(data);
 };
 
-export { log, spinner, emptyLine, getPkg, primaryChalk, convertToTitleCase };
+export {
+  log,
+  spinner,
+  logError,
+  emptyLine,
+  getPkg,
+  primaryChalk,
+  convertToTitleCase,
+};


### PR DESCRIPTION
### Description

- Added support for `customTemplate` in arclix config.

### Additional context

Now the developer's can create their own custom templates for `component`, `style`, `story` and `test` files for generation using Arclix.

The basic template of config with `customTemplate` will look like:
```json
{
    "generate":  {
        "default": {
            "customTemplate": {
                "component": "path to component template",
                "style": "path to style template",
                "test": "path to test template",
                "story": "path to story template",
            }
            // other configuration...
        }
    }
}
```

> **Note:** For now only the components named `TemplateComponent ` is supported as templates for `customTemplate`.


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/arclix/core/blob/master/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/arclix/core/blob/master/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/arclix/core/blob/master/.github/COMMIT_CONVENTION.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
